### PR TITLE
Add SPARQL examples and regional music queries

### DIFF
--- a/readMe_interactiveSemanticIQA_AI_agentVersion2.md
+++ b/readMe_interactiveSemanticIQA_AI_agentVersion2.md
@@ -20,10 +20,257 @@ Example questions:
 - main/home page: http://101.201.37.120:8080/mcdemo/home
 - SPARQL query page: http://101.201.37.120:8080/mcdemo/sparql
 
-# SPARQL endpoint from open link virtuoso
+# SPARQL endpoint (终端) from open link virtuoso
 http://101.201.37.120:8890/sparql
  
-# Query Examples
-## 3.1.1 > (4) Hybrid query scope across T‑Box and A‑Box
+# Query Examples (for the paper _"Interactive Semantic Intelligent Question-Answering Agent (Enhanced Version 2.0) for an Interoperable Chinese Traditional Music Linked Data Platform"_)
+## 3.1.1 > (4) Hybrid query scope across T‑Box and A‑Box (to be added soon)
 ```sparql
+# to be added soon
 ```
+
+## 针对论文《知识图谱+大模型：中华传统音乐文化知识库关联数据“互操作”平台—智能体与“知识地图”前导性研究——兼论音乐数字人文潜学科群新方向》
+### 三、 > （二） > 问题：“北省石家庄市及与其相邻2步长（毗邻关系）范围内的其他城市（含下辖县区级行政单位）有什么乐种？这些乐种中，哪些又能关联到中国音乐学院图书馆的特藏资源？“
+```sparql
+define input:inference 'urn:owl.ccmusicrules0913' # 用于Open Link Virtuoso中激活推理机
+PREFIX bf: <http://id.loc.gov/ontologies/bibframe/>
+PREFIX ctm: <https://lib.ccmusic.edu.cn/ontologies/chinese_traditional_music#>
+PREFIX gn: <https://www.geonames.org/ontology#>
+PREFIX places: <http://purl.org/ontology/places#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+# 注意：激活下方的变量?distance，则可显示相应的边列表关系是第几步长范围内的
+SELECT distinct ?source ?sourceLabel ?target ?targetLabel ?relationType #?distance
+WHERE {
+  # Identify 石家庄市 as our starting point
+  ?shijiazhuang rdfs:label "石家庄市" .
+  ?shijiazhuang a places:City .
+  
+  {
+    # Part 1: City-to-City connections 城市间的毗邻关系
+    {
+      # Direct neighbors (1 step)
+      ?shijiazhuang gn:neighbour ?target .
+      BIND(?shijiazhuang AS ?source)
+      BIND(1 AS ?distance)
+      BIND(gn:neighbour AS ?relationType)
+    } 
+    UNION 
+    {
+      # 2 steps away
+      ?shijiazhuang gn:neighbour ?intermediate1 .
+      ?intermediate1 gn:neighbour ?target .
+      FILTER(?target != ?shijiazhuang)  # Avoid cycles back to origin
+      BIND(?intermediate1 AS ?source)
+      BIND(2 AS ?distance)
+      BIND(gn:neighbour AS ?relationType)
+    }
+    
+    # Get readable labels for cities
+    ?source rdfs:label ?sourceLabel .
+    ?target rdfs:label ?targetLabel .
+  }
+  
+  UNION
+  
+  {
+    # Part 2: County-to-City relationships 县、区级行政单位到市级行政单位的信息
+   {
+   # Direct parent-child relationship - counties of Shijiazhuang
+    ?county gn:parentADM2 ?shijiazhuang .
+    ?county a places:County .
+    ?county rdfs:label ?sourceLabel .
+    ?shijiazhuang rdfs:label ?targetLabel .
+    BIND(?county AS ?source)
+    BIND(?shijiazhuang AS ?target)
+    BIND(gn:parentADM2 AS ?relationType)
+  }
+  UNION
+  {
+    # Counties of neighboring cities
+    ?shijiazhuang gn:neighbour ?neighborCity .
+    ?neighborCity a places:City .
+    ?county gn:parentADM2 ?neighborCity .
+    ?county a places:County .
+    ?county rdfs:label ?sourceLabel .
+    ?neighborCity rdfs:label ?targetLabel .
+    BIND(?county AS ?source)
+    BIND(?neighborCity AS ?target)
+    BIND(gn:parentADM2 AS ?relationType)
+  }
+  UNION
+  {
+    # Counties of cities 2 steps away
+    ?shijiazhuang gn:neighbour ?intermediate1 .
+    ?intermediate1 gn:neighbour ?distantCity .
+    FILTER(?distantCity != ?shijiazhuang)
+    ?distantCity a places:City .
+    ?county gn:parentADM2 ?distantCity .
+    ?county a places:County .
+    ?county rdfs:label ?sourceLabel .
+    ?distantCity rdfs:label ?targetLabel .
+    BIND(?county AS ?source)
+    BIND(?distantCity AS ?target)
+    BIND(gn:parentADM2 AS ?relationType)
+  }
+}
+  
+  UNION
+  
+   {
+   # Part 3: MusicType-to-County relationships 乐种及其分布地域（仅以县区级行政单位为例）
+   {
+    # Music types related to counties in Shijiazhuang
+    ?county gn:parentADM2 ?shijiazhuang .
+    ?county a places:County .
+    ?musicType bf:place ?county .
+    ?musicType rdfs:label ?sourceLabel .
+    ?county rdfs:label ?targetLabel .
+    BIND(?musicType AS ?source)
+    BIND(?county AS ?target)
+    BIND(bf:place AS ?relationType)
+    FILTER(LANG(?sourceLabel) != "py")
+  }
+  UNION
+  {
+    # Music types related to counties in neighboring cities
+    ?shijiazhuang gn:neighbour ?neighborCity .
+    ?neighborCity a places:City .
+    ?county gn:parentADM2 ?neighborCity .
+    ?county a places:County .
+    ?musicType bf:place ?county .
+    ?musicType rdfs:label ?sourceLabel .
+    ?county rdfs:label ?targetLabel .
+    BIND(?musicType AS ?source)
+    BIND(?county AS ?target)
+    BIND(bf:place AS ?relationType)
+    FILTER(LANG(?sourceLabel) != "py")
+  }
+  UNION
+  {
+    # Music types related to counties in cities 2 steps away
+    ?shijiazhuang gn:neighbour ?intermediate1 .
+    ?intermediate1 gn:neighbour ?distantCity .
+    FILTER(?distantCity != ?shijiazhuang)
+    ?distantCity a places:City .
+    ?county gn:parentADM2 ?distantCity .
+    ?county a places:County .
+    ?musicType bf:place ?county .
+    ?musicType rdfs:label ?sourceLabel .
+    ?county rdfs:label ?targetLabel .
+    BIND(?musicType AS ?source)
+    BIND(?county AS ?target)
+    BIND(bf:place AS ?relationType)
+    FILTER(LANG(?sourceLabel) != "py")
+  }
+  }
+  
+  UNION
+  
+    {
+    # Part 4: SpecialIndependentResource-to-MusicType relationships 特藏独立资源及其涉及的乐种
+  {
+    # specialResources related to musicTypes in Shijiazhuang counties
+    ?county gn:parentADM2 ?shijiazhuang .
+    ?county a places:County .
+    ?musicType bf:place ?county .
+    ?specialResource a ctm:SpecialIndependentResource .
+    ?specialResource ctm:relatesMusicType ?musicType .
+    ?specialResource rdfs:label ?sourceLabel .
+    ?musicType rdfs:label ?targetLabel .
+    BIND(?specialResource AS ?source)
+    BIND(?musicType AS ?target)
+    BIND(ctm:relatesMusicType AS ?relationType)
+    FILTER(LANG(?targetLabel) != "py")
+  }
+  UNION
+  {
+    # specialResources related to musicTypes in neighboring cities' counties
+    ?shijiazhuang gn:neighbour ?neighborCity .
+    ?neighborCity a places:City .
+    ?county gn:parentADM2 ?neighborCity .
+    ?county a places:County .
+    ?musicType bf:place ?county .
+    ?specialResource a ctm:SpecialIndependentResource .
+    ?specialResource ctm:relatesMusicType ?musicType .
+    ?specialResource rdfs:label ?sourceLabel .
+    ?musicType rdfs:label ?targetLabel .
+    BIND(?specialResource AS ?source)
+    BIND(?musicType AS ?target)
+    BIND(ctm:relatesMusicType AS ?relationType)
+    FILTER(LANG(?targetLabel) != "py")
+  }
+  UNION
+  {
+    # specialResources related to musicTypes in counties of cities 2 steps away
+    ?shijiazhuang gn:neighbour ?intermediate1 .
+    ?intermediate1 gn:neighbour ?distantCity .
+    FILTER(?distantCity != ?shijiazhuang)
+    ?distantCity a places:City .
+    ?county gn:parentADM2 ?distantCity .
+    ?county a places:County .
+    ?musicType bf:place ?county .
+    ?specialResource a ctm:SpecialIndependentResource .
+    ?specialResource ctm:relatesMusicType ?musicType .
+    ?specialResource rdfs:label ?sourceLabel .
+    ?musicType rdfs:label ?targetLabel .
+    BIND(?specialResource AS ?source)
+    BIND(?musicType AS ?target)
+    BIND(ctm:relatesMusicType AS ?relationType)
+    FILTER(LANG(?targetLabel) != "py")
+  }
+  }
+}
+```
+
+### 三、 > （三） > 问题：“湖北省荆门市（市中心为东宝区）方圆75公里内有哪些乐种，其中，哪些在我们图书馆有收藏？“
+```sparql
+define input:inference 'urn:owl.ccmusicrules0913' # 用于激活推理机
+PREFIX gn: <https://www.geonames.org/ontology#>
+PREFIX ctm: <https://lib.ccmusic.edu.cn/ontologies/chinese_traditional_music#>
+PREFIX bf: <http://id.loc.gov/ontologies/bibframe/>
+PREFIX wdt: <http://www.wikidata.org/prop/direct/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+select distinct ?OtherCity ?otherCityLab ?OtherCounty ?coordin ?otherCounLab ?distan ?MTForCity ?mTFCityLab ?mTFCounty ?mTFCounLab ?Reso # ?resouL # ?MusicType2 
+where {
+  # （1）找到荆门市中心的东宝区的坐标，以及东宝区可能存在的音乐类型(乐种)：
+  ?CenterCounty rdfs:label "东宝区" ;
+                           wdt:P625 ?centerCoordinateLocation .
+   # optional { ?MusicType1 bf:place ?CenterCounty ; a ctm:MusicType } # [随后事实发现，并没有音乐类型(乐种)是直接关联东宝区的]
+  # （2）规定好备选的其他县区级行政单位的坐标，以及其所隶属的市级行政单位，以及隶属于该县区级行政单位的乡镇级行政单位：
+  ?OtherCounty wdt:P625 ?coordin ; # P625为坐标属性
+                          gn:parentADM2 ?OtherCity ; # 县、区级行政单位地域隶属于某市级行政单位?OtherCity      
+                          rdfs:label ?otherCounLab .
+  ?OtherCity rdfs:label ?otherCityLab .
+  # ?OtherTown gn:parentADM3 ?OtherCounty . # 某些乡镇级行政单位?OtherTown隶属于该县级行政单位（假定一个县区级行政单位必然有下辖的乡镇级行政单位）
+  # （3）如果某些音乐类型(乐种)的分布地域是那些县区级或市级行政单位，进而，如果这些音乐类型涉及到我馆的特藏独立资源
+  optional { 
+    ?mTFCounty a ctm:MusicType ;
+                          bf:place ?OtherCounty ;
+                          rdfs:label ?mTFCounLab .
+    FILTER(LANG(?mTFCounLab) != "py")
+    optional { ?mTFCounty ctm:relatesWork ?Reso .
+               #?SpecialIndependentResource rdfs:label ?resouL
+}
+  }
+  
+  optional { 
+    ?MTForCity a ctm:MusicType ;
+                        bf:place ?OtherCity ;
+                        rdfs:label ?mTFCityLab .
+    FILTER(LANG(?mTFCityLab) != "py")
+    optional { ?MTForCity ctm:relatesWork ?Reso .
+               #?SpecialIndependentResource rdfs:label ?resouL
+}
+  }
+#  optional { ?MusicType2 a ctm:MusicType ; 
+#                                         bf:place ?OtherTown . # [可能并有音乐类型(乐种)是直接关联此片县级行政单位下属的乡镇级行政单位的，为了本案例研究的简约性，暂对此略去]
+#             optional { ?MusicType2 ctm:relatesWork ?SpecialIndependentResource . }}
+#（4）计算东宝区和其他县级行政单位之间的距离，设筛选条件为75公里之内
+  bind (bif:st_distance(?centerCoordinateLocation, ?coordin) AS ?distan)
+  filter (?distan<=75)
+} 
+group by ?OtherCity ?otherCityLab ?OtherCounty ?coordin ?otherCounLab ?distan ?MTForCity ?mTFCityLab ?mTFCounty ?mTFCounLab ?Reso # ?resouL # ?MusicType2 # 为了避免返回的数据行有重复，故加group by
+order by ?distan
+


### PR DESCRIPTION
Extended readMe_interactiveSemanticIQA_AI_agentVersion2.md with detailed SPARQL examples for the project/paper. Updated the SPARQL endpoint label (including Chinese), added a placeholder for hybrid T‑Box/A‑Box queries, and appended multiple complex queries: a multi-part query centered on 石家庄市 to retrieve neighboring cities, counties, music types and library special resources (with inference activation, labels, language filters and relation typing), and a distance-based query for 荆门市·东宝区 to find music types within 75 km (using coordinate distance calculation). Includes relevant PREFIX declarations and notes about activating the Virtuoso inference engine.